### PR TITLE
Add README and formula for homebrew raiden installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,71 @@
+# homebrew-raiden
+
+Homebrew Tap for Raiden
+
+**Important note: reporting issues with any of these brews should be done at their respective repositories ([Raiden](https://github.com/raiden-network/raiden)).**
+
+## Installation
+
+```
+$ brew tap raiden-network/raiden
+```
+
+```
+$ brew install raiden
+```
+
+## Running
+
+You should now be able to run the raiden network by using the following:
+```
+$ raiden
+```
+
+
+#### Important note when using --successful
+
+If you get an error looking like this:
+```
+==> Cloning https://github.com/raiden-network/raiden.git
+Updating /Library/Caches/Homebrew/raiden--git
+fatal: reference is not a tree: <latest commit hash>
+Error: Failed to download resource "raiden"
+Failure while executing: git checkout -q -f
+```
+
+Try to delete the cache with `rm -rf /Library/Caches/Homebrew/raiden-git`
+
+
+## Upgrading
+
+```
+brew update && brew upgrade
+```
+
+## Versions
+List available versions with:
+```
+ls -l /usr/local/Cellar/raiden
+```
+
+If you have other versions installed, you can switch with:
+```
+brew switch raiden <version>
+```
+Or follow this [StackOverflow answer](http://stackoverflow.com/a/9832084/2639784)
+
+These brews can be installed via the raw GitHub URLs, or by cloning this
+repository locally with `brew tap raiden-network/raiden`. You can also install binary
+bottles directly with `brew install <bottle_url>`.
+
+
+## Troubleshooting
+
+* Use `--verbose` to get more info while installing.
+* Make sure to update XCode and the command line tools.
+* Run `brew update` and `brew upgrade`
+* Fix what the `brew doctor` says.
+* Reinstall dependencies: `brew reinstall boost --c++11 --with-python`
+* Make changes to `/usr/local/Library/Taps/raiden-network/homebrew-raiden/raiden.rb`
+* Reinstall with `brew reinstall raiden.rb` (send a pull request!)
+* Take a walk

--- a/raiden.rb
+++ b/raiden.rb
@@ -1,0 +1,18 @@
+class Raiden < Formula
+  desc "Raiden Network"
+  homepage "https://github.com/cpurta/homebrew-raiden"
+  url "https://github.com/raiden-network/raiden/releases/download/v0.3.0/raiden-v0.3.0-macOS.zip"
+  version "v0.3.0"
+  sha256 "3f34d241f6b23d30d69c7bd25fa62de280e5f2bb34f9c08340f3e390e80e2809"
+
+  depends_on :macos => :el_capitan
+
+  def install
+    system "mv", "raiden-0.3.0-macos", "raiden"
+    bin.install "raiden"
+  end
+
+  test do
+    system "#{bin}/raiden", "version"
+  end
+end


### PR DESCRIPTION
Add the formula for installing raiden on Mac using Homebrew. This will satisfy part of the requirements needed for https://github.com/raiden-network/raiden/issues/1243. 